### PR TITLE
Bug in entity to catch preapproval for suscription

### DIFF
--- a/Entity/Ipn.php
+++ b/Entity/Ipn.php
@@ -24,7 +24,7 @@ class Ipn
      *
      */
     protected $topic = '';
-    /** @ORM\Column(type="integer") */
+    /** @ORM\Column(type="string", length=50) */
     protected $operation_id;
     /**
      * @ORM\Column(type="datetime")


### PR DESCRIPTION
operation_id on Ipn.php should be string to be able to catch preapproval as come in response to suscription IPN from MP


